### PR TITLE
Fix issue #9

### DIFF
--- a/doc/install.tex
+++ b/doc/install.tex
@@ -206,11 +206,10 @@ $ cat sv_out/counter.sv              # see generated SystemVerilog file
 
 SystemC simulation for examples and tests can be run with:
 \begin{lstlisting}[language=bash]
-$ cd $ICSC_HOME
-$ mkdir build && cd build
+$ cd $ICSC_HOME/build
 $ cmake ../                          # prepare Makefiles 
 $ make counter                       # compile SystemC simulation for counter example
-$ cd examples/counter                # go to counter example folder
+$ cd icsc/examples/counter           # go to counter example folder
 $ ./counter                          # run SystemC simulation 
 \end{lstlisting}
 

--- a/examples/counter/example.cpp
+++ b/examples/counter/example.cpp
@@ -18,19 +18,38 @@ struct Tb : sc_module
     sc_signal<bool>         even{"even"};
  
     Dut dut_inst{"dut_inst"};
+    
+    void print_method(){
+        cout <<clk.read()<<"\t\t"<<sc_time_stamp()<<"\t\t"<<rstn.read()<<"\t\t"<<counter.read()<<"\t\t"<<even.read()<<endl;
+    }
+
+    void reset_test(){
+            rstn.write(1);
+            wait(2, SC_NS);
+            rstn.write(0);
+            wait(3, SC_NS);
+            rstn.write(1);
+            wait();
+    }
 
     SC_CTOR(Tb) 
     {
+        SC_THREAD(reset_test);
+        sensitive << rstn;
         dut_inst.clk(clk);
         dut_inst.rstn(rstn);
         dut_inst.counter(counter);
         dut_inst.even(even);
+        SC_METHOD(print_method);
+        sensitive << counter;
     }
 };
  
 int sc_main (int argc, char **argv) 
 {
     Tb tb("tb");
-    sc_start();
+    cout <<"Clock\t\tTime\t\tReset\t\tCounter\t\tEven" << endl;
+    sc_start(22, SC_NS);
+    cout <<"\n\t\t*****Simulation complete*****" << endl;
     return 0;
 }


### PR DESCRIPTION
[Issue 9](https://github.com/intel/systemc-compiler/issues/9)

1. In the "Getting Started Wiki" ->  "Run SystemC Simulation" subsection: on second command, it is not required to do "mkdir build" since build directory already exists. The counter example folder is in "build/icsc/examples", not "build/examples". So I fixed these errors.
2. Enhanced testbench and stopped simulation from hanging.
Simulation used to hang since the time to stop was not mentioned. I fixed this. I also added a function to test reset and to print the signals and to print a message "simulation complete" once the simulation is done. This gives the user a feedback of the simulation results.

The output now looks like this:

```
shashank@shashank-desktop:~/systemc-compiler/build$ cd icsc/examples/counter && ./counter

        SystemC 2.3.3-Accellera --- Jun 16 2021 21:27:55
        Copyright (c) 1996-2018 by all Contributors,
        ALL RIGHTS RESERVED
Clock           Time            Reset           Counter         Even
0               0 s             0               0               0
1               1 ns            1               1               0
1               2 ns            0               0               1
1               5 ns            1               1               0
1               6 ns            1               2               1
1               7 ns            1               3               0
1               8 ns            1               4               1
1               9 ns            1               5               0
1               10 ns           1               6               1
1               11 ns           1               7               0
1               12 ns           1               8               1
1               13 ns           1               9               0
1               14 ns           1               10              1
1               15 ns           1               11              0
1               16 ns           1               12              1
1               17 ns           1               13              0
1               18 ns           1               14              1
1               19 ns           1               15              0
1               20 ns           1               0               1
1               21 ns           1               1               0

                *****Simulation complete*****
shashank@shashank-desktop:~/systemc-compiler/build/icsc/examples/counter$  

```
