### PR TITLE
Fixes Linux commands and SystemC simulation of counter

### DIFF
--- a/doc/install.tex
+++ b/doc/install.tex
@@ -198,7 +198,7 @@ Generated SystemVerilog files are put into {\tt sv\_out} folders.
 For {\tt counter} example:
 % 
 \begin{lstlisting}[language=bash]
-$ cd examples/counter                # go to counter example folder 
+$ cd icsc/examples/counter                # go to counter example folder 
 $ cat sv_out/counter.sv              # see generated SystemVerilog file 
 \end{lstlisting}
 

--- a/doc/install.tex
+++ b/doc/install.tex
@@ -206,11 +206,10 @@ $ cat sv_out/counter.sv              # see generated SystemVerilog file
 
 SystemC simulation for examples and tests can be run with:
 \begin{lstlisting}[language=bash]
-$ cd $ICSC_HOME
-$ mkdir build && cd build
+$ cd $ICSC_HOME/build
 $ cmake ../                          # prepare Makefiles 
 $ make counter                       # compile SystemC simulation for counter example
-$ cd examples/counter                # go to counter example folder
+$ cd icsc/examples/counter           # go to counter example folder
 $ ./counter                          # run SystemC simulation 
 \end{lstlisting}
 

--- a/doc/install.tex
+++ b/doc/install.tex
@@ -206,7 +206,8 @@ $ cat sv_out/counter.sv              # see generated SystemVerilog file
 
 SystemC simulation for examples and tests can be run with:
 \begin{lstlisting}[language=bash]
-$ cd $ICSC_HOME/build
+$ cd $ICSC_HOME
+$ mkdir -p build && cd build
 $ cmake ../                          # prepare Makefiles 
 $ make counter                       # compile SystemC simulation for counter example
 $ cd icsc/examples/counter           # go to counter example folder

--- a/examples/counter/example.cpp
+++ b/examples/counter/example.cpp
@@ -18,19 +18,38 @@ struct Tb : sc_module
     sc_signal<bool>         even{"even"};
  
     Dut dut_inst{"dut_inst"};
+    
+    void print_method(){
+        cout <<clk.read()<<"\t\t"<<sc_time_stamp()<<"\t\t"<<rstn.read()<<"\t\t"<<counter.read()<<"\t\t"<<even.read()<<endl;
+    }
+
+    void reset_test(){
+            rstn.write(1);
+            wait(2, SC_NS);
+            rstn.write(0);
+            wait(3, SC_NS);
+            rstn.write(1);
+            wait();
+    }
 
     SC_CTOR(Tb) 
     {
+        SC_THREAD(reset_test);
+        sensitive << rstn;
         dut_inst.clk(clk);
         dut_inst.rstn(rstn);
         dut_inst.counter(counter);
         dut_inst.even(even);
+        SC_METHOD(print_method);
+        sensitive << counter;
     }
 };
  
 int sc_main (int argc, char **argv) 
 {
     Tb tb("tb");
-    sc_start();
+    cout <<"Clock\t\tTime\t\tReset\t\tCounter\t\tEven" << endl;
+    sc_start(22, SC_NS);
+    cout <<"\n\t\t*****Simulation complete*****" << endl;
     return 0;
 }


### PR DESCRIPTION
To fix Issue #9 
1. Fixes Linux commands in the doc (tex file).
2. Enhanced testbench for counter simulation so it won't hang. Counter simulation now looks like this:
```

        SystemC 2.3.3-Accellera --- Jun 16 2021 21:27:55
        Copyright (c) 1996-2018 by all Contributors,
        ALL RIGHTS RESERVED
Clock           Time            Reset           Counter         Even
0               0 s             0               0               0
1               1 ns            1               1               0
1               2 ns            0               0               1
1               5 ns            1               1               0
1               6 ns            1               2               1
1               7 ns            1               3               0
1               8 ns            1               4               1
1               9 ns            1               5               0
1               10 ns           1               6               1
1               11 ns           1               7               0
1               12 ns           1               8               1
1               13 ns           1               9               0
1               14 ns           1               10              1
1               15 ns           1               11              0
1               16 ns           1               12              1
1               17 ns           1               13              0
1               18 ns           1               14              1
1               19 ns           1               15              0
1               20 ns           1               0               1
1               21 ns           1               1               0

                *****Simulation complete*****
```