### PR TITLE
Use std::size_t in place of size_t

### DIFF
--- a/sc_tool/lib/sc_tool/elab/ScElabModuleBuilder.h
+++ b/sc_tool/lib/sc_tool/elab/ScElabModuleBuilder.h
@@ -20,7 +20,7 @@ class ElabDatabase;
 
 /// Creates Verilog modules inside elaboration database
 void buildVerilogModules(sc_elab::ElabDatabase *elabDB,
-                         const std::unordered_map<size_t, size_t>& movedObjs);
+                         const std::unordered_map<std::size_t, std::size_t>& movedObjs);
 
 } // end namespace sc
 


### PR DESCRIPTION
During build process, build stops when it cannot find size_t definition
for ScElabModuleBuilder.h

Replacing `size_t` with `std::size_t` fixes the issue, and allows for
successful build.