### PR TITLE
Fixed install script for macOS

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1,0 +1,103 @@
+#!/bin/bash -e
+
+#********************************************************************************
+# Copyright (c) 2020-2023, Intel Corporation. All rights reserved.              #
+#                                                                               #
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.                      #
+#                                                                               #
+#********************************************************************************
+
+#################################################################################
+# This bash script downloads and builds Protobuf, Clang/LLVM, GDB (optional),   #
+# builds and installs ICSC, runs ICSCS examples.                                #
+# To build GDB with Python3 compatible with SystemC pretty printers use:        #
+# ./install.sh gdb                                                              #
+#################################################################################
+
+test -z $ICSC_HOME && { echo "ICSC_HOME is not configured"; exit 1; }
+echo "Using ICSC_HOME = $ICSC_HOME"
+
+export CWD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo $CWD_DIR
+export CMAKE_PREFIX_PATH=$ICSC_HOME:$CMAKE_PREFIX_PATH
+export GCC_INSTALL_PREFIX="$(realpath "$(dirname $(which g++))"/..)"
+
+echo "Downloading and building Protobuf/LLVM at $CWD_DIR/build_deps..."
+mkdir -p build_deps && cd build_deps
+
+# ################################################################################
+# Download, unpack, build, install Protobuf 3.13
+wget -N https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz --no-check-certificate
+tar -xf v3.13.0.tar.gz 
+(
+    cd protobuf-3.13.0
+    mkdir -p build_folder && cd build_folder
+    cmake ../cmake/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ICSC_HOME -DBUILD_SHARED_LIBS=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_STANDARD=17
+    make -j
+    make install
+)
+
+# ################################################################################
+# Download, unpack, build, install Clang and LLVM
+wget -N https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang-12.0.1.src.tar.xz --no-check-certificate
+wget -N https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/llvm-12.0.1.src.tar.xz --no-check-certificate
+tar -xf clang-12.0.1.src.tar.xz 
+tar -xf llvm-12.0.1.src.tar.xz 
+ln -sf ../../clang-12.0.1.src llvm-12.0.1.src/tools/clang
+(
+    cd llvm-12.0.1.src
+    mkdir -p build && cd build
+    cmake ../ -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_TARGETS_TO_BUILD="X86" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ICSC_HOME -DGCC_INSTALL_PREFIX=$GCC_INSTALL_PREFIX -DCMAKE_CXX_STANDARD=17
+    make -j
+    make install
+)
+
+# ################################################################################
+# Download, unpack, build, install GDB with Python3
+if [[ $1 == gdb ]]
+then
+   wget -N https://ftp.gnu.org/gnu/gdb/gdb-11.2.tar.gz --no-check-certificate
+   tar -xf gdb-11.2.tar.gz
+   (
+       cd gdb-11.2
+       ./configure --prefix="$ICSC_HOME" --with-python="$(which python3)"
+       make -j
+       make install
+   )
+fi
+
+# ################################################################################
+# Build and install ISCC
+cd $CWD_DIR
+(
+    mkdir -p build_icsc_rel && cd build_icsc_rel
+    cmake ../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ICSC_HOME -DCMAKE_CXX_STANDARD=17
+    make -j
+    make install
+    
+    cd ..
+    
+    mkdir -p build_icsc_dbg && cd build_icsc_dbg
+    cmake ../ -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_INSTALL_PREFIX=$ICSC_HOME -DCMAKE_CXX_STANDARD=17 -DCMAKE_DEBUG_POSTFIX=d
+    make -j12
+    make install
+
+    cp $CWD_DIR/cmake/CMakeLists.top $ICSC_HOME/CMakeLists.txt
+)
+
+echo "*** ISCC Build and Installation Complete! ***"
+
+
+# ################################################################################
+# Build and run examples
+echo "*** Building Examples ***"
+cd $ICSC_HOME
+(
+    ln -s $ICSC_HOME/icsc/components/common $ICSC_HOME/designs/single_source/common
+    source setenv.sh
+    mkdir -p build && cd build
+    cmake ../                          # prepare Makefiles
+    cd designs/examples                # run examples only
+    ctest -j12                         # compile and run Verilog generation
+                                       # use "-jN" key to run in "N" processes
+)


### PR DESCRIPTION
Hello,

please consider this as a "work-in-progress PR", since we have for sure to discuss these steps. The goal is to port systems-compiler to macOS. The install script has some issues with respect to mkdir or wget, since these shell commands work differently on macOS compared to linux. A script for macOS is included in this pull request. 

Unfortunately, beside these small cosmetics, there seems to be a more difficult issue that I was not able to solve so far. The step _Build and install ISCC_ is failing because som c-headers could not be found. I think they belong to the standard library, however we don't build this library here, we just build the compiler and not a libc etc... ISCC is also compiled using the previously build compiler:

```
Consolidate compiler generated dependencies of target SysCRTTI
[ 66%] Generating SystemC precompiled header /Users/myzinsky/Zeugs/sc_tools/icsc/build_icsc_rel/systemc/systemc.h.pch
/Users/myzinsky/Zeugs/sc_tools/bin/clang++ -Xclang -emit-pch -x c++-header /Users/myzinsky/Zeugs/sc_tools/icsc/systemc/src/systemc.h -o /Users/myzinsky/Zeugs/sc_tools/icsc/build_icsc_rel/systemc/systemc.h.pch -D__SC_TOOL__ -D__SC_TOOL_ANALYZE__ -DNDEBUG -std=c++17 -I/Users/myzinsky/Zeugs/sc_tools/icsc/systemc/src
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f sc_tool/CMakeFiles/SysCRTTI.dir/build.make sc_tool/CMakeFiles/SysCRTTI.dir/build
/Users/myzinsky/Zeugs/sc_tools/icsc/systemc/src/systemc.h:43:10: fatal error: 'cassert' file not found
#include <cassert>
         ^~~~~~~~~
make[2]: Nothing to be done for `sc_tool/CMakeFiles/SysCRTTI.dir/build'.
[ 68%] Built target SysCRTTI
1 error generated.
make[2]: *** [systemc/systemc.h.pch] Error 1
make[1]: *** [CMakeFiles/systemcPCH.dir/all] Error 2
make: *** [all] Error 2
``` 

Any thoughts?